### PR TITLE
Add dual solution to return values

### DIFF
--- a/reluqp/classes.py
+++ b/reluqp/classes.py
@@ -89,8 +89,9 @@ class Info(object):
 
 
 class Results(object):
-    def __init__(self, x=None, z=None, info: Info=None):
+    def __init__(self, x=None, z=None, lam=None, info: Info=None):
         self.x = x
         self.z = z
+        self.lam = lam
         self.info = info
 

--- a/reluqp/reluqpth.py
+++ b/reluqp/reluqpth.py
@@ -286,6 +286,7 @@ class ReLU_QP(object):
 
         self.results.x = self.x
         self.results.z = self.z
+        self.results.lam = self.lam
 
         self.results.info.iter = iter
         self.results.info.status = status


### PR DESCRIPTION
This adds the dual solution to the return values of the solver.
Including the dual solution can be beneficial for general use. Moreover, it is essential for integrating the solver into the [qpsolvers](https://github.com/qpsolvers/qpsolvers) and the [qpbenchmark](https://github.com/qpsolvers/qpbenchmark) repositories. They provide a common interface for using multiple QP solvers and a benchmarking library, respectively.
The changes are minimal and straightforward.