### PR TITLE
Make ReLU-QP woring on CPU

### DIFF
--- a/reluqp/reluqpth.py
+++ b/reluqp/reluqpth.py
@@ -85,11 +85,10 @@ class ReLU_Layer(torch.nn.Module):
     
     @torch.jit.script
     def jit_forward(input, W, b, l, u, idx1: int, idx2: int):
-        torch.matmul(W, input, out=input)
-        input.add_(b)
-        input[idx1:idx2].clamp_(l, u)
-        return input
-    
+        out = torch.matmul(W, input) + b
+        out[idx1:idx2].clamp_(l, u)
+        return out
+
 
 class ReLU_QP(object):
     def __init__(self):


### PR DESCRIPTION
I noticed that some operations in the current code fail when running without a CUDA-enabled GPU.

- Timing: The implementation used `torch.cuda.Event`, which only works with CUDA. This has been updated to use the standard Python `time` module when CUDA is not available, ensuring correct timing on both CPU and GPU.

- `jit_forward` method: The previous version used `torch.matmul(W, input, out=input)`. On CPU, this causes incorrect results because the out tensor overlaps with an input operand. The fix replaces it with an assignment to a new tensor, which avoids overlapping writes.
